### PR TITLE
Remove faraday version dependency.

### DIFF
--- a/faraday-request-timer.gemspec
+++ b/faraday-request-timer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "mocha",   "~> 1.1.0"


### PR DESCRIPTION
@johncalvinyoung and I tested this on Faraday up to 0.14 (latest) and it appears to still be functional. The gem seems to work fine with the latest Faraday without issue, but the dependency version prior to this restricted it to a particularly old Faraday. Alternatively, I suppose we could make this point to `~> 0.14` or otherwise restrict it, but at the moment this seems to work well enough.

Unless you've let this go due to (undocumented) functionality existing in the core of Faraday, this is still contextually better than just getting an `ActiveSupport::Notification` and having to parse it separately.

_Edited: Add a description._