### PR TITLE
Update to use latest Faraday

### DIFF
--- a/faraday-request-timer.gemspec
+++ b/faraday-request-timer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday", ">= 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "mocha",   "~> 1.1.0"


### PR DESCRIPTION
Opening a new PR to address comments since the original branch was not on a fork that I can edit.

From original PR #1 :

> @johncalvinyoung and I tested this on Faraday up to 0.14 (latest) and it appears to still be functional. The gem seems to work fine with the latest Faraday without issue, but the dependency version prior to this restricted it to a particularly old Faraday. 

Update: Restricts to version `>= 0.9.0` to allow for upgrading Faraday to latest.