### PR TITLE
Upgrade and add minitest as a dependency

### DIFF
--- a/faraday-request-timer.gemspec
+++ b/faraday-request-timer.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 0.9.0"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "mocha",   "~> 1.1.0"
+  spec.add_development_dependency "bundler",  "~> 1.5"
+  spec.add_development_dependency "minitest", "~> 5.11.3"
+  spec.add_development_dependency "mocha",    "~> 1.1.0"
 end


### PR DESCRIPTION
This fix was required to get the tests running on my machine.