### PR TITLE
Add total request timeout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Or install it yourself as:
 
 ```ruby
 connection = Faraday::Connection.new do |builder|
-  builder.request :timer
+  builder.request :timer # timeout: option available
   builder.adapter Faraday.default_adapter
 end
 

--- a/lib/faraday/request/timer.rb
+++ b/lib/faraday/request/timer.rb
@@ -3,12 +3,22 @@ module Faraday
 
     Faraday::Request.register_middleware :timer => self
 
+    def initialize(app, options = {})
+      super(app)
+      @timeout = options[:timeout]
+    end
+
     def call(env)
       started_at = Time.now
       app        = @app.call(env)
       ended_at   = Time.now
 
-      app.env[:duration] = ended_at - started_at
+      duration = ended_at - started_at
+      app.env[:duration] = duration
+      if @timeout && duration > @timeout
+        raise Faraday::TimeoutError
+      end
+
       app
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,14 +7,4 @@ require "mocha/setup"
 
 class Minitest::Spec
 
-  def connection
-    Faraday::Connection.new("http://example.net") do |builder|
-      builder.request :timer
-
-      builder.adapter :test do |stubs|
-        yield(stubs)
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
This branch allows the middleware to raise a `Faraday::TimeoutError` if the total request time is exceeded. 

This is useful because the underlying timeouts through the various Faraday adapters often have simpler network based timeouts, like open or read timeouts, which are easy to exceed. It's important to understand this does not stop the request which may be long running, but just stops the response from being returned.