### PR TITLE
Gemspec: Allow Bundler 2, mention Rake

### DIFF
--- a/faraday-request-timer.gemspec
+++ b/faraday-request-timer.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 0.9.0"
 
-  spec.add_development_dependency "bundler",  "~> 1.5"
+  spec.add_development_dependency "bundler",  ">= 1.5"
   spec.add_development_dependency "minitest", "~> 5.11.3"
   spec.add_development_dependency "mocha",    "~> 1.1.0"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR changes the dev dependency version range on Bundler to make it possible to develop using Bundler 2.0, also.

In order to avoid an error about missing rake, I also added `rake` as a development dependency.